### PR TITLE
Avoid git requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 pbr>=0.6,!=0.7,<1.0
 Babel>=1.3
 
-git+git://git.openstack.org/openstack/designate.git@stable/kilo#egg=designate-2015.1.1
+designate>=2015.1


### PR DESCRIPTION
Installing the repo with pip failed due to: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
